### PR TITLE
Fix branching for a few repos for syncing

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -165,7 +165,7 @@
   <!-- External -->
   <project name="android_external_f2fs-tools" path="external/f2fs-tools" remote="XOS" />
   <project name="LineageOS/android_external_chromium-webview" path="external/chromium-webview"
-           remote="github" revision="cm-14.1" clone-depth="1" />
+           remote="github" revision="master" clone-depth="1" />
 
   <!-- Hardware -->
   <include name="hals/hals.xml" />

--- a/hals/hals.xml
+++ b/hals/hals.xml
@@ -11,7 +11,7 @@
   <project path="hardware/qcom/audio-caf/msm8994" name="android_hardware_qcom_audio" groups="qcom,qcom_audio" remote="XOS" revision="cm-14.1-caf-8994" />
   <project path="hardware/qcom/audio-caf/msm8996" name="android_hardware_qcom_audio" groups="qcom,qcom_audio" remote="XOS" revision="cm-14.1-caf-8996" />
   <project path="hardware/qcom/audio-caf/msm8998" name="android_hardware_qcom_audio" groups="qcom,qcom_audio" remote="XOS" revision="cm-14.1-caf-8998" />
-  <project path="hardware/qcom/bootctrl" name="android_hardware_qcom_bootctrl" groups="pdk" remote="XOS" revision="cm-14.1" />
+  <project path="hardware/qcom/bootctrl" name="android_hardware_qcom_bootctrl" groups="pdk" remote="XOS" />
   <project path="hardware/qcom/bt" name="android_hardware_qcom_bt" groups="qcom" remote="XOS" revision="cm-14.1" />
   <project path="hardware/qcom/bt-caf" name="android_hardware_qcom_bt" groups="qcom" remote="XOS" revision="cm-14.1-caf" />
   <project path="hardware/qcom/camera" name="android_hardware_qcom_camera" groups="qcom" remote="XOS" revision="XOS-7.1" />


### PR DESCRIPTION
* Branch for `hardware/qcom/bootctrl` was changed from `cm-14.1` to
  `XOS-7.1`. Remove branch override for this repo so it defaults to
  that branch.

```
error: Cannot checkout android_hardware_qcom_bootctrl: ManifestInvalidRevisionError: revision cm-14.1 in android_hardware_qcom_bootctrl not found
(...)
error: in `sync --force-sync`: revision cm-14.1 in android_hardware_qcom_bootctrl not found
```

* Also, as seen on almost all Nougat ROMs, branch for
  `LineageOS:external/chromium-webview` was set to `cm-14.1`,
  which doesn't exist since a long time ago. Also sort that out.

```
error: Cannot checkout LineageOS/android_external_chromium-webview: ManifestInvalidRevisionError: revision cm-14.1 in LineageOS/android_external_chromium-webview not found
error: in `sync --force-sync`: revision cm-14.1 in LineageOS/android_external_chromium-webview not found
```

Signed-off-by: Beru Shinsetsu <windowz414@projectkasumi.xyz>